### PR TITLE
Fix a flaky test by initializing a container to clean pollution

### DIFF
--- a/cynergy/tests/test_register_multiple.py
+++ b/cynergy/tests/test_register_multiple.py
@@ -35,6 +35,7 @@ class Main2(object):
 
 
 def test_register_multiple():
+    container.initialize()
     container.register_many(Example, [Example1, Example2])
     instance = container.get(List[Example])
 

--- a/cynergy/tests/test_register_multiple.py
+++ b/cynergy/tests/test_register_multiple.py
@@ -35,7 +35,7 @@ class Main2(object):
 
 
 def test_register_multiple():
-    container.initialize()
+    container._clear_all()
     container.register_many(Example, [Example1, Example2])
     instance = container.get(List[Example])
 


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test `cynergy/tests/test_register_multiple.py::test_register_multiple`, which can fail after running `cynergy/tests/test_register_multiple.py::test_multiple_list_arguments_with_wrap`, but passes when it is run in isolation.

# Reproduce the test failure
Run the following command:
```
python -m pytest cynergy/tests/test_register_multiple.py::test_multiple_list_arguments_with_wrap cynergy/tests/test_register_multiple.py::test_register_multiple
```
# Expected result
Test `cynergy/tests/test_register_multiple.py::test_register_multiple` should pass when it is run after test  `cynergy/tests/test_register_multiple.py::test_multiple_list_arguments_with_wrap`

# Actual result
Test `cynergy/tests/test_register_multiple.py::test_register_multiple` fails:
```
E       AssertionError: assert <class 'cynergy.tests.test_register_multiple.Example2'> is Example1
E        +  where <class 'cynergy.tests.test_register_multiple.Example2'> = type(<cynergy.tests.test_register_multiple.Example2 object at 0x7f6699140eb0>)
```
# Why it fails:
After running `cynergy/tests/test_register_multiple.py::test_multiple_list_arguments_with_wrap`, the `container` is polluted.

# Fix:
- Initialize a new container each time before `cynergy/tests/test_register_multiple.py::test_register_multiple` runs.
- Another fix is `container._clear_all()`